### PR TITLE
Handle vendor prefixed expressions

### DIFF
--- a/lib/calc.js
+++ b/lib/calc.js
@@ -36,8 +36,10 @@ module.exports = function (style) {
  * Constants
  */
 var DEFAULT_UNIT = 'px',
-    EXPRESSION_METHOD_NAME = 'calc',
-    EXPRESSION_REGEXP = '\\b' + EXPRESSION_METHOD_NAME + '\\(';
+    EXPRESSION_METHOD_NAME =  'calc',
+    EXPRESSION_OPT_VENDOR_PREFIX = '(\\-[a-z]+\\-)?',
+    EXPRESSION_METHOD_REGEXP = EXPRESSION_OPT_VENDOR_PREFIX + EXPRESSION_METHOD_NAME,
+    EXPRESSION_REGEXP = '\\b' + EXPRESSION_METHOD_REGEXP + '\\(';
 
 /**
  * Visit all rules
@@ -123,7 +125,11 @@ function evaluateAndApplyExpressions(expressions, declaration) {
         if (!result) return;
 
         // Insert the evaluated value:
-        declaration.value = declaration.value.replace(EXPRESSION_METHOD_NAME + '(' + expression + ')', result);
+        var expRegexp = new RegExp(
+                                EXPRESSION_METHOD_REGEXP + '\\(' +
+                                escapeExp(expression) + '\\)'
+                            );
+        declaration.value = declaration.value.replace(expRegexp, result);
     });
 }
 
@@ -200,4 +206,15 @@ function getUnitsInExpression(expression) {
     }
 
     return uniqueUnits;
+}
+
+/**
+ * Escape string for inclusion in a regex pattern without conflicts
+ *
+ * @param  {String} str String to escape
+ * @return {String} Escaped string
+ * @api private
+ */
+function escapeExp(str) {
+    return String(str).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
 }

--- a/test/calc-prefix.in.css
+++ b/test/calc-prefix.in.css
@@ -1,0 +1,14 @@
+
+body > header {
+  height: -webkit-calc(100% - 2em);
+  width: -moz-calc(50% - 2em);
+}
+
+body > nav {
+  height: -moz-calc(100px / 2);
+}
+
+h2 {
+  font-size: -webkit-calc(120% * 50%);
+  line-height: -moz-calc(2 * 50%);
+}

--- a/test/calc-prefix.out.css
+++ b/test/calc-prefix.out.css
@@ -1,0 +1,13 @@
+body > header {
+  height: -webkit-calc(100% - 2em);
+  width: -moz-calc(50% - 2em);
+}
+
+body > nav {
+  height: 50px;
+}
+
+h2 {
+  font-size: 60%;
+  line-height: 100%;
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -36,4 +36,12 @@ describe('rework-calc', function() {
       .toString()
       .should.equal(css.out('calc-complex'));
   });
+
+  it('should handle vendor prefixed expressions', function () {
+    rework(css.in('calc-prefix'))
+      .use(calc)
+      .toString()
+      .should.equal(css.out('calc-prefix'));
+  });
+
 });


### PR DESCRIPTION
A case found while processing 3rd party code. Input:

``` css
  min-width: -webkit-calc(99%);
```

Output was:

``` css
  min-width: -webkit-99%;
```

Let me know if you want any changes.
