### PR TITLE
Resolve nested calc() whenever it's possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "mocha": "~1.15.1",
-    "rework": "^1.0.0"
+    "rework": "^1.0.0",
+    "rework-vars": "^3.1.1"
   },
   "files": [
     "index.js"

--- a/test/fixtures/calc-complex.in.css
+++ b/test/fixtures/calc-complex.in.css
@@ -1,6 +1,18 @@
+:root {
+  --fontSizeUnit: 1rem;
+  --fontSizeRatio: 0.75;
+  --fontSize: calc(var(--fontSizeUnit) * var(--fontSizeRatio));
+  --lineHeight: calc(var(--fontSize) * 1.5);
 
-body > header,
-body > section,
-body > footer {
-  width: calc(100% - 2em);
+  --gutter-y: var(--lineHeight);
+
+  --zIndexOverlay: 100;
+  --zIndexThing: calc(var(--zIndexOverlay) + 10);
+}
+
+stuff {
+  resolved: calc(var(--gutter-y) - 1rem) otherfn(blah);
+  unresolved: calc(var(--gutter-y) - 1px);
+  prefixed-unresolved: -webkit-calc(var(--gutter-y) - 1px);
+  z-index: calc(var(--zIndexThing) + 1);
 }

--- a/test/fixtures/calc-complex.out.css
+++ b/test/fixtures/calc-complex.out.css
@@ -1,5 +1,6 @@
-body > header,
-body > section,
-body > footer {
-  width: calc(100% - 2em);
+stuff {
+  resolved: 0.125rem otherfn(blah);
+  unresolved: calc(1.125rem - 1px);
+  prefixed-unresolved: -webkit-calc(1.125rem - 1px);
+  z-index: 111;
 }

--- a/test/fixtures/calc-fallback.in.css
+++ b/test/fixtures/calc-fallback.in.css
@@ -1,0 +1,6 @@
+
+body > header,
+body > section,
+body > footer {
+  width: calc(100% - 2em);
+}

--- a/test/fixtures/calc-fallback.out.css
+++ b/test/fixtures/calc-fallback.out.css
@@ -1,0 +1,5 @@
+body > header,
+body > section,
+body > footer {
+  width: calc(100% - 2em);
+}

--- a/test/fixtures/calc.in.css
+++ b/test/fixtures/calc.in.css
@@ -4,6 +4,11 @@ body {
 }
 
 body > header {
-  height: calc(3em * 2);
-  font-size: calc(6em / 2);
+  prop: calc(3px * 2);
+  prop: calc(3px * 2) 1em;
+  prop: 1em calc(3px * 2);
+  prop: calc(3px * 2) 1em calc(3px * 2);
+  prop: 1em calc(3px * 2) 1em calc(3px * 2);
+  prop: 1em calc(3px * 2) 1em calc(3px * 2) 1em;
+  font-size: calc((6em / 2) + 1em);
 }

--- a/test/fixtures/calc.out.css
+++ b/test/fixtures/calc.out.css
@@ -3,6 +3,11 @@ body {
 }
 
 body > header {
-  height: 6em;
-  font-size: 3em;
+  prop: 6px;
+  prop: 6px 1em;
+  prop: 1em 6px;
+  prop: 6px 1em 6px;
+  prop: 1em 6px 1em 6px;
+  prop: 1em 6px 1em 6px 1em;
+  font-size: 4em;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var calc = require('..');
 var read = require('fs').readFileSync;
 var rework = require('rework');
+var vars = require('rework-vars');
 
 function fixture(name) {
   return read('test/fixtures/' + name + '.css', 'utf8').trim();
@@ -37,10 +38,21 @@ describe('rework-calc', function () {
   });
 
   it('should use CSS3 Calc function as fallback for expressions with multiple units', function () {
-    compareFixtures('calc-complex');
+    compareFixtures('calc-fallback');
   });
 
   it('should handle vendor prefixed expressions', function () {
     compareFixtures('calc-prefix');
+  });
+
+  it('should resolve what is possible in complex calc whenever it\'s possible', function () {
+    var name = 'calc-complex'
+    var actual = rework(fixture(name + '.in'))
+      .use(vars())
+      .use(calc)
+      .toString()
+      .trim();
+    var expected = fixture(name + '.out');
+    return assert.equal(actual, expected);
   });
 });


### PR DESCRIPTION
This also include
- more use of balanced-match
- error per expression
- drop default unit (for example, z-index doesn’t require one)
- more complex tests

Close #5 

poke @necolas (I hope I'm not bothering you, but nobody is watching this repo :D)
