### PR TITLE
Keep inner function calls untouched

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,12 @@ function evaluateExpression (expression) {
 
   var balancedExpr = balanced('(', ')', expression);
   if (balancedExpr && balancedExpr.body !== '') {
-    expression = balancedExpr.pre + evaluateExpression(balancedExpr.body).value + balancedExpr.post;
+    hasPre = Boolean(balancedExpr.pre);
+    expression = balancedExpr.pre +
+                 (hasPre ? '(' : '') +
+                 evaluateExpression(balancedExpr.body).value + 
+                 (hasPre ? ')' : '') +
+                 balancedExpr.post;
   }
 
   var units = getUnitsInExpression(expression);

--- a/index.js
+++ b/index.js
@@ -99,12 +99,10 @@ function evaluateExpression (expression) {
 
   var balancedExpr = balanced('(', ')', expression);
   if (balancedExpr && balancedExpr.body !== '') {
-    hasPre = Boolean(balancedExpr.pre);
-    expression = balancedExpr.pre +
-                 (hasPre ? '(' : '') +
-                 evaluateExpression(balancedExpr.body).value + 
-                 (hasPre ? ')' : '') +
-                 balancedExpr.post;
+    var hasPre = Boolean(balancedExpr.pre);
+    expression = balancedExpr.pre + (hasPre ? '(' : '') +
+      evaluateExpression(balancedExpr.body).value + 
+      (hasPre ? ')' : '') + balancedExpr.post;
   }
 
   var units = getUnitsInExpression(expression);

--- a/test/fixtures/calc-functions.in.css
+++ b/test/fixtures/calc-functions.in.css
@@ -1,0 +1,5 @@
+stuff {
+  inner-var: calc(var(--some-var) - 1rem) otherfn(blah);
+  inner-function: calc(somefn(value) + 10px);
+  width: calc(10px + 100px);
+}

--- a/test/fixtures/calc-functions.out.css
+++ b/test/fixtures/calc-functions.out.css
@@ -1,0 +1,5 @@
+stuff {
+  inner-var: calc(var(--some-var) - 1rem) otherfn(blah);
+  inner-function: calc(somefn(value) + 10px);
+  width: 110px;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,10 @@ describe('rework-calc', function () {
     compareFixtures('calc-prefix');
   });
 
+  it('should leave inner function calls untouched', function () {
+    compareFixtures('calc-functions');
+  });
+
   it('should resolve what is possible in complex calc whenever it\'s possible', function () {
     var name = 'calc-complex'
     var actual = rework(fixture(name + '.in'))


### PR DESCRIPTION
fixes `calc(var(--length) * 2)`
for cases when you generate both: legacy css with precalculated values and modern css.
